### PR TITLE
Set fov_desired max value to 130, fix FOV not changing + slider issues

### DIFF
--- a/src/game/client/portal/clientmode_portal.cpp
+++ b/src/game/client/portal/clientmode_portal.cpp
@@ -22,7 +22,7 @@
 
 // default FOV for HL2
 ConVar default_fov( "default_fov", "75", FCVAR_CHEAT );
-ConVar fov_desired( "fov_desired", "75", FCVAR_ARCHIVE | FCVAR_USERINFO, "Sets the base field-of-view.", true, 75.0, true, 90.0 );
+ConVar fov_desired( "fov_desired", "75", FCVAR_ARCHIVE | FCVAR_USERINFO, "Sets the base field-of-view.", true, 75.0, true, MAX_FOV );
 
 
 // The current client mode. Always ClientModeNormal in HL.

--- a/src/game/shared/gamerules.cpp
+++ b/src/game/shared/gamerules.cpp
@@ -916,7 +916,7 @@ void CGameRules::ClientSettingsChanged( CBasePlayer *pPlayer )
 	if ( pszFov )
 	{
 		int iFov = atoi(pszFov);
-		iFov = clamp( iFov, 75, 90 );
+		iFov = clamp( iFov, 75, 130 );
 		pPlayer->SetDefaultFOV( iFov );
 	}
 

--- a/src/game/shared/portal/portal_gamerules.cpp
+++ b/src/game/shared/portal/portal_gamerules.cpp
@@ -426,7 +426,7 @@ void CPortalGameRules::ClientSettingsChanged( CBasePlayer *pPlayer )
 	const char* pszFov = engine->GetClientConVarValue(pPlayer->entindex(),
 		"fov_desired");
 	int iFov = atoi(pszFov);
-	iFov = clamp(iFov, 70, MAX_FOV);
+	iFov = clamp(iFov, 75, MAX_FOV);
 	pPortalPlayer->SetDefaultFOV(iFov);
 
 	BaseClass::ClientSettingsChanged(pPlayer);

--- a/src/game/shared/portal/portal_gamerules.cpp
+++ b/src/game/shared/portal/portal_gamerules.cpp
@@ -423,6 +423,12 @@ void CPortalGameRules::ClientSettingsChanged( CBasePlayer *pPlayer )
 
 	pPortalPlayer->SetupSkin();
 
+	const char* pszFov = engine->GetClientConVarValue(pPlayer->entindex(),
+		"fov_desired");
+	int iFov = atoi(pszFov);
+	iFov = clamp(iFov, 70, MAX_FOV);
+	pPortalPlayer->SetDefaultFOV(iFov);
+
 	BaseClass::ClientSettingsChanged(pPlayer);
 #endif
 

--- a/src/game/shared/shareddefs.h
+++ b/src/game/shared/shareddefs.h
@@ -234,7 +234,7 @@ enum CastVote
 
 #define MAX_PLACE_NAME_LENGTH		18
 
-#define MAX_FOV						90
+#define MAX_FOV						130
 
 //===================================================================================================================
 // Team Defines


### PR DESCRIPTION
Increases max_fov to allow for up to a value of 130.

This would help players on standard widescreen monitors be able to see as much as players on ultrawide displays, help reduce nausea, to have parity with Valve's other titles such as Left 4 Dead 2 as well as other Portal modding communities who typically allow a higher max FOV setting.

During testing, it was found that changing the fov_desired command and using the slider did not change the FOV whatsoever, which was a separate issue. This has also been resolved with this.