### PR TITLE
[CODE] - player FOV, viewmodel FOV, wall tearing

### DIFF
--- a/src/game/client/portal/clientmode_portal.cpp
+++ b/src/game/client/portal/clientmode_portal.cpp
@@ -22,7 +22,7 @@
 
 // default FOV for HL2
 ConVar default_fov( "default_fov", "75", FCVAR_CHEAT );
-ConVar fov_desired( "fov_desired", "75", FCVAR_ARCHIVE | FCVAR_USERINFO, "Sets the base field-of-view.", true, 75.0, true, 90.0 );
+ConVar fov_desired( "fov_desired", "75", FCVAR_ARCHIVE | FCVAR_USERINFO, "Sets the base field-of-view.", true, 75.0, true, MAX_FOV );
 
 
 // The current client mode. Always ClientModeNormal in HL.

--- a/src/game/client/view.cpp
+++ b/src/game/client/view.cpp
@@ -110,7 +110,7 @@ static ConVar v_centerspeed( "v_centerspeed","500" );
 // and motions look the most natural.
 ConVar v_viewmodel_fov( "viewmodel_fov", "54", FCVAR_ARCHIVE, "Sets the field-of-view for the viewmodel.", true, 0.1, true, 179.9, true, 54, true, 70, NULL );
 #else
-ConVar v_viewmodel_fov( "viewmodel_fov", "54", FCVAR_CHEAT, "Sets the field-of-view for the viewmodel.", true, 0.1, true, 179.9 );
+ConVar v_viewmodel_fov( "viewmodel_fov", "54", FCVAR_ARCHIVE, "Sets the field-of-view for the viewmodel.", true, 0.1, true, 179.9 );
 #endif
 ConVar mat_viewportscale( "mat_viewportscale", "1.0", FCVAR_ARCHIVE, "Scale down the main viewport (to reduce GPU impact on CPU profiling)", true, (1.0f / 640.0f), true, 1.0f );
 ConVar mat_viewportupscale( "mat_viewportupscale", "1", FCVAR_ARCHIVE, "Scale the viewport back up" );

--- a/src/game/client/view.cpp
+++ b/src/game/client/view.cpp
@@ -109,8 +109,10 @@ static ConVar v_centerspeed( "v_centerspeed","500" );
 // 54 degrees approximates a 35mm camera - we determined that this makes the viewmodels
 // and motions look the most natural.
 ConVar v_viewmodel_fov( "viewmodel_fov", "54", FCVAR_ARCHIVE, "Sets the field-of-view for the viewmodel.", true, 0.1, true, 179.9, true, 54, true, 70, NULL );
-#else
+#elif defined ( PORTAL )
 ConVar v_viewmodel_fov( "viewmodel_fov", "54", FCVAR_ARCHIVE, "Sets the field-of-view for the viewmodel.", true, 0.1, true, 179.9 );
+#else
+ConVar v_viewmodel_fov( "viewmodel_fov", "54", FCVAR_CHEAT, "Sets the field-of-view for the viewmodel.", true, 0.1, true, 179.9 );
 #endif
 ConVar mat_viewportscale( "mat_viewportscale", "1.0", FCVAR_ARCHIVE, "Scale down the main viewport (to reduce GPU impact on CPU profiling)", true, (1.0f / 640.0f), true, 1.0f );
 ConVar mat_viewportupscale( "mat_viewportupscale", "1", FCVAR_ARCHIVE, "Scale the viewport back up" );

--- a/src/game/client/view.h
+++ b/src/game/client/view.h
@@ -23,7 +23,7 @@ class VPlane;
 
 // near and far Z it uses to render the world.
 #ifndef HL1_CLIENT_DLL
-#define VIEW_NEARZ	7
+#define VIEW_NEARZ	3
 #else
 #define VIEW_NEARZ	3
 #endif

--- a/src/game/client/view.h
+++ b/src/game/client/view.h
@@ -22,10 +22,12 @@ class VPlane;
 
 
 // near and far Z it uses to render the world.
-#ifndef HL1_CLIENT_DLL
+#ifdef HL1_CLIENT_DLL
+#define VIEW_NEARZ	3
+#elif defined ( PORTAL )
 #define VIEW_NEARZ	3
 #else
-#define VIEW_NEARZ	3
+#define VIEW_NEARZ	7
 #endif
 //#define VIEW_FARZ	28400
 

--- a/src/game/shared/gamerules.cpp
+++ b/src/game/shared/gamerules.cpp
@@ -929,7 +929,7 @@ void CGameRules::ClientSettingsChanged( CBasePlayer *pPlayer )
 	if ( pszFov )
 	{
 		int iFov = atoi(pszFov);
-		iFov = clamp( iFov, 75, 90 );
+		iFov = clamp( iFov, 75, 120 );
 		pPlayer->SetDefaultFOV( iFov );
 	}
 

--- a/src/game/shared/shareddefs.h
+++ b/src/game/shared/shareddefs.h
@@ -271,7 +271,7 @@ inline bool IsIndexIntoPlayerArrayValid( int iIndex )
 
 #define MAX_PLACE_NAME_LENGTH		18
 
-#define MAX_FOV						90
+#define MAX_FOV						120
 
 //===================================================================================================================
 // Team Defines


### PR DESCRIPTION
The following changes bring the project to have the same settings as retail Portal:
- Increases FOV up to 120
- Changes viewmodel_fov from an fcvar_cheat to an fcvar_archive, so players are allowed to increase their viewmodel FOV without cheats enabled.

Wall tearing/clipping change:
- At higher FOVs, you can see through walls you are standing beside. Changing the view_nearz value to 3 fixes this issue.